### PR TITLE
Fixed compass overwriting main hand when auto-looting full grave

### DIFF
--- a/src/main/java/com/ranull/graves/listener/PlayerInteractListener.java
+++ b/src/main/java/com/ranull/graves/listener/PlayerInteractListener.java
@@ -102,9 +102,6 @@ public class PlayerInteractListener implements Listener {
                         if (!locationList.isEmpty()) {
                             Location location = locationList.get(0);
 
-                            player.getInventory().setItem(player.getInventory().getHeldItemSlot(),
-                                    plugin.getEntityManager().createGraveCompass(player, location, grave));
-
                             if (player.getWorld().equals(location.getWorld())) {
                                 plugin.getEntityManager().sendMessage("message.distance", player,
                                         location, grave);


### PR DESCRIPTION
The line removed here caused the grave compass to overwrite the item in the main hand if the player died with a full inventory and an item in their offhand. I could not find any situation where this line did anything productive other than causing this bug, so I decided to just remove it entirely.