### PR TITLE
Fixed compass overwriting main hand issue more correctly.

### DIFF
--- a/src/main/java/com/ranull/graves/listener/PlayerInteractListener.java
+++ b/src/main/java/com/ranull/graves/listener/PlayerInteractListener.java
@@ -89,7 +89,8 @@ public class PlayerInteractListener implements Listener {
             }
 
             // Compass
-            if (event.getItem() != null) {
+            if (event.getItem() != null &&
+                    player.getInventory().getItem(player.getInventory().getHeldItemSlot()) == event.getItem()) {
                 ItemStack itemStack = event.getItem();
                 UUID uuid = plugin.getEntityManager().getGraveUUIDFromItemStack(itemStack);
 


### PR DESCRIPTION
Found the real source of the issue and fixed it properly.
The changed block of code is responsible for updating the compass when the compass is interacted with, it does this by blindly overwriting the item in the held item slot, assuming that it's still the compass. Since so many things are happening in this one listener, it's pretty common that the held item has already been modified due to the grave being auto-looted by the time the compass is being updated, so I just added a check that the currently held item is still the same item used to fire the `PlayerInteractEvent`, which has properly solved the issue and still allows the compass to be updated in the case that anything about the connected grave has changed.