### PR TITLE
Fix death event priority and grave displays

### DIFF
--- a/src/main/java/org/avarion/graves/Graves.java
+++ b/src/main/java/org/avarion/graves/Graves.java
@@ -16,53 +16,10 @@ import org.avarion.graves.command.GravesCommand;
 import org.avarion.graves.command.GraveyardsCommand;
 import org.avarion.graves.compatibility.Compatibility;
 import org.avarion.graves.compatibility.CompatibilityBlockData;
-import org.avarion.graves.listener.BlockBreakListener;
-import org.avarion.graves.listener.BlockExplodeListener;
-import org.avarion.graves.listener.BlockFromToListener;
-import org.avarion.graves.listener.BlockPistonExtendListener;
-import org.avarion.graves.listener.BlockPlaceListener;
-import org.avarion.graves.listener.CreatureSpawnListener;
-import org.avarion.graves.listener.EntityDamageByEntityListener;
-import org.avarion.graves.listener.EntityDeathListener;
-import org.avarion.graves.listener.EntityExplodeListener;
-import org.avarion.graves.listener.HangingBreakListener;
-import org.avarion.graves.listener.InventoryClickListener;
-import org.avarion.graves.listener.InventoryCloseListener;
-import org.avarion.graves.listener.InventoryDragListener;
-import org.avarion.graves.listener.InventoryOpenListener;
-import org.avarion.graves.listener.PlayerBucketEmptyListener;
-import org.avarion.graves.listener.PlayerDeathListener;
-import org.avarion.graves.listener.PlayerDropItemListener;
-import org.avarion.graves.listener.PlayerInteractAtEntityListener;
-import org.avarion.graves.listener.PlayerInteractEntityListener;
-import org.avarion.graves.listener.PlayerInteractListener;
-import org.avarion.graves.listener.PlayerJoinListener;
-import org.avarion.graves.listener.PlayerMoveListener;
-import org.avarion.graves.listener.PlayerQuitListener;
-import org.avarion.graves.listener.PlayerRespawnListener;
-import org.avarion.graves.manager.BlockManager;
-import org.avarion.graves.manager.CacheManager;
-import org.avarion.graves.manager.DataManager;
-import org.avarion.graves.manager.EntityDataManager;
-import org.avarion.graves.manager.EntityManager;
-import org.avarion.graves.manager.GUIManager;
-import org.avarion.graves.manager.GraveManager;
-import org.avarion.graves.manager.GraveyardManager;
-import org.avarion.graves.manager.HologramManager;
-import org.avarion.graves.manager.ImportManager;
-import org.avarion.graves.manager.IntegrationManager;
-import org.avarion.graves.manager.ItemStackManager;
-import org.avarion.graves.manager.LocationManager;
-import org.avarion.graves.manager.RecipeManager;
-import org.avarion.graves.manager.VersionManager;
+import org.avarion.graves.listener.*;
+import org.avarion.graves.manager.*;
 import org.avarion.graves.type.Grave;
-import org.avarion.graves.util.FileUtil;
-import org.avarion.graves.util.HastebinUtil;
-import org.avarion.graves.util.ResourceUtil;
-import org.avarion.graves.util.ServerUtil;
-import org.avarion.graves.util.UUIDUtil;
-import org.avarion.graves.util.UpdateUtil;
-import org.avarion.graves.util.YAMLUtil;
+import org.avarion.graves.util.*;
 import org.bstats.bukkit.Metrics;
 import org.bstats.charts.SingleLineChart;
 import org.bukkit.ChatColor;
@@ -250,15 +207,8 @@ public class Graves extends JavaPlugin {
 
     public void registerListeners() {
         // Configurable death listener priority
-        String priorityStr = getConfig().getString("settings.listener-priority.death");
-        EventPriority priority;
-        try {
-            priority = EventPriority.valueOf(priorityStr.toUpperCase());
-        } catch (IllegalArgumentException e) {
-            getLogger().warning("Invalid event priority in config: " + priorityStr + ". Defaulting to HIGHEST.");
-            priority = EventPriority.HIGHEST;
-        }
-        getServer().getPluginManager().registerEvent(PlayerDeathEvent.class, new Listener() {}, priority, new PlayerDeathListener(this), this, true);
+        getServer().getPluginManager().registerEvent(PlayerDeathEvent.class, new Listener() {}, 
+                getEventPriority("death"), new PlayerDeathListener(this), this, true);
         
         // All other non-configurable listeners
         getServer().getPluginManager().registerEvents(new PlayerInteractListener(this), this);
@@ -286,6 +236,17 @@ public class Graves extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new BlockExplodeListener(this), this);
 
         //getServer().getPluginManager().registerEvents(new GraveTestListener(this), this); // Test Listener
+    }
+    
+    // Get priority for a type. Currently only "death" is available
+    private EventPriority getEventPriority(String type) {
+        String priorityStr = getConfig().getString("settings.listener-priority." + type);
+        try {
+            return EventPriority.valueOf(priorityStr.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            getLogger().warning("Invalid event priority in config for type '" + type + "': " + priorityStr + ". Defaulting to HIGHEST.");
+            return EventPriority.HIGHEST;
+        }
     }
 
     public void unregisterListeners() {

--- a/src/main/java/org/avarion/graves/listener/PlayerDeathListener.java
+++ b/src/main/java/org/avarion/graves/listener/PlayerDeathListener.java
@@ -1,19 +1,19 @@
 package org.avarion.graves.listener;
 
-import org.avarion.graves.Graves;
-import org.avarion.graves.manager.CacheManager;
-import org.bukkit.event.EventHandler;
-import org.bukkit.event.EventPriority;
-import org.bukkit.event.Listener;
-import org.bukkit.event.entity.PlayerDeathEvent;
-import org.bukkit.inventory.ItemStack;
-import org.jetbrains.annotations.NotNull;
-
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-public class PlayerDeathListener implements Listener {
+import org.avarion.graves.Graves;
+import org.avarion.graves.manager.CacheManager;
+import org.bukkit.event.Event;
+import org.bukkit.event.EventException;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.EventExecutor;
+
+public class PlayerDeathListener implements EventExecutor {
 
     private final Graves plugin;
 
@@ -21,9 +21,13 @@ public class PlayerDeathListener implements Listener {
         this.plugin = plugin;
     }
 
-    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
-    public void onPlayerDeathEvent(@NotNull PlayerDeathEvent event) {
-        List<ItemStack> itemStackList = event.getDrops();
+    @Override
+    public void execute(Listener listener, Event event) throws EventException {
+        if (!(event instanceof PlayerDeathEvent deathEvent)) {
+            return;
+        }
+        
+        List<ItemStack> itemStackList = deathEvent.getDrops();
         Iterator<ItemStack> iterator = itemStackList.iterator();
 
         while (iterator.hasNext()) {
@@ -31,14 +35,14 @@ public class PlayerDeathListener implements Listener {
 
             if (itemStack != null) {
                 if (plugin.getEntityManager().getGraveUUIDFromItemStack(itemStack) != null
-                    && plugin.getConfigBool("compass.destroy", event.getEntity())) {
+                    && plugin.getConfigBool("compass.destroy", deathEvent.getEntity())) {
                     iterator.remove();
                 }
             }
         }
 
         CacheManager.removedItemStackMap
-              .put(event.getEntity().getUniqueId(), new ArrayList<>(itemStackList));
+              .put(deathEvent.getEntity().getUniqueId(), new ArrayList<>(itemStackList));
     }
 
 }

--- a/src/main/java/org/avarion/graves/listener/PlayerDeathListener.java
+++ b/src/main/java/org/avarion/graves/listener/PlayerDeathListener.java
@@ -21,7 +21,7 @@ public class PlayerDeathListener implements Listener {
         this.plugin = plugin;
     }
 
-    @EventHandler(priority = EventPriority.LOWEST)
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onPlayerDeathEvent(@NotNull PlayerDeathEvent event) {
         List<ItemStack> itemStackList = event.getDrops();
         Iterator<ItemStack> iterator = itemStackList.iterator();

--- a/src/main/java/org/avarion/graves/listener/PlayerInteractAtEntityListener.java
+++ b/src/main/java/org/avarion/graves/listener/PlayerInteractAtEntityListener.java
@@ -32,7 +32,8 @@ public class PlayerInteractAtEntityListener implements Listener {
             Grave grave = plugin.getEntityDataManager().getGrave(entity);
 
             if (grave != null) {
-                event.setCancelled(plugin.getGraveManager().openGrave(player, entity.getLocation(), grave));
+                event.setCancelled(true);
+                plugin.getGraveManager().openGrave(player, entity.getLocation(), grave);
             }
         }
     }

--- a/src/main/java/org/avarion/graves/listener/PlayerInteractEntityListener.java
+++ b/src/main/java/org/avarion/graves/listener/PlayerInteractEntityListener.java
@@ -32,7 +32,8 @@ public class PlayerInteractEntityListener implements Listener {
             Grave grave = plugin.getEntityDataManager().getGrave(entity);
 
             if (grave != null) {
-                event.setCancelled(plugin.getGraveManager().openGrave(player, entity.getLocation(), grave));
+                event.setCancelled(true);
+                plugin.getGraveManager().openGrave(player, entity.getLocation(), grave);
             }
         }
     }

--- a/src/main/resources/config/config.yml
+++ b/src/main/resources/config/config.yml
@@ -22,6 +22,16 @@ settings:
   # Data storage system.
   cache:
     type: NORMAL # Cache type.
+    
+  #####################
+  # Listener Priority #
+  #####################
+  # The listener priority of the death event.
+  # Options: LOWEST, LOW, NORMAL, HIGH, HIGHEST, MONITOR
+  # The default option should work with most plugins. Unless you know what you are
+  # doing, you should leave this at HIGHEST.
+  listener-priority:
+    death: HIGHEST    
 
   #########
   # Debug #


### PR DESCRIPTION
While configuring this plugin for my server, I noticed a couple bugs that can be patched up quite easily.

Event priority execution order goes from `LOWEST` to `MONITOR`, meaning events with higher priority actually execute later. Changing the death event listener from `LOWEST` to `HIGHEST` allows other plugins to change the drops before this plugin wipes and stores them away in a grave. I think it would be best if in the future, a config option was added for this.

Interacting with entities should be cancelled no matter what happens if a grave is detected. If these events are not cancelled, players can take items from item frames, and take the equipment off of armor stands.