### PR TITLE
Move configurable priority to correct listener

### DIFF
--- a/src/main/java/org/avarion/graves/Graves.java
+++ b/src/main/java/org/avarion/graves/Graves.java
@@ -35,7 +35,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
-import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.permissions.PermissionAttachmentInfo;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.Contract;
@@ -207,8 +207,8 @@ public class Graves extends JavaPlugin {
 
     public void registerListeners() {
         // Configurable death listener priority
-        getServer().getPluginManager().registerEvent(PlayerDeathEvent.class, new Listener() {}, 
-                getEventPriority("death"), new PlayerDeathListener(this), this, true);
+        getServer().getPluginManager().registerEvent(EntityDeathEvent.class, new Listener() {}, 
+                getEventPriority("death", EventPriority.MONITOR), new EntityDeathListener(this), this, true);
         
         // All other non-configurable listeners
         getServer().getPluginManager().registerEvents(new PlayerInteractListener(this), this);
@@ -219,9 +219,9 @@ public class Graves extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new PlayerQuitListener(this), this);
         getServer().getPluginManager().registerEvents(new PlayerRespawnListener(this), this);
         getServer().getPluginManager().registerEvents(new PlayerDropItemListener(this), this);
+        getServer().getPluginManager().registerEvents(new PlayerDeathListener(this), this);
         getServer().getPluginManager().registerEvents(new EntityExplodeListener(this), this);
         getServer().getPluginManager().registerEvents(new EntityDamageByEntityListener(this), this);
-        getServer().getPluginManager().registerEvents(new EntityDeathListener(this), this);
         getServer().getPluginManager().registerEvents(new BlockPlaceListener(this), this);
         getServer().getPluginManager().registerEvents(new BlockBreakListener(this), this);
         getServer().getPluginManager().registerEvents(new BlockFromToListener(this), this);
@@ -239,13 +239,13 @@ public class Graves extends JavaPlugin {
     }
     
     // Get priority for a type. Currently only "death" is available
-    private EventPriority getEventPriority(String type) {
+    private EventPriority getEventPriority(String type, EventPriority defaultPriority) {
         String priorityStr = getConfig().getString("settings.listener-priority." + type);
         try {
             return EventPriority.valueOf(priorityStr.toUpperCase());
         } catch (IllegalArgumentException e) {
-            getLogger().warning("Invalid event priority in config for type '" + type + "': " + priorityStr + ". Defaulting to HIGHEST.");
-            return EventPriority.HIGHEST;
+            getLogger().warning("Invalid event priority in config for type '" + type + "': " + priorityStr + ". Defaulting to " + defaultPriority);
+            return defaultPriority;
         }
     }
 

--- a/src/main/java/org/avarion/graves/listener/EntityDeathListener.java
+++ b/src/main/java/org/avarion/graves/listener/EntityDeathListener.java
@@ -1,5 +1,13 @@
 package org.avarion.graves.listener;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
 import org.avarion.graves.Graves;
 import org.avarion.graves.data.BlockData;
 import org.avarion.graves.event.GraveBlockPlaceEvent;
@@ -14,19 +22,17 @@ import org.bukkit.entity.Creature;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
-import org.bukkit.event.EventHandler;
-import org.bukkit.event.EventPriority;
+import org.bukkit.event.Event;
+import org.bukkit.event.EventException;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.inventory.ItemStack;
-import org.jetbrains.annotations.NotNull;
+import org.bukkit.plugin.EventExecutor;
 
-import java.util.*;
-
-public class EntityDeathListener implements Listener {
+public class EntityDeathListener implements EventExecutor {
 
     private final Graves plugin;
 
@@ -34,8 +40,12 @@ public class EntityDeathListener implements Listener {
         this.plugin = plugin;
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
-    public void onEntityDeath(@NotNull EntityDeathEvent event) {
+    @Override
+    public void execute(Listener listener, Event initEvent) throws EventException {
+        if (!(initEvent instanceof EntityDeathEvent event)) {
+            return;
+        }
+        
         LivingEntity livingEntity = event.getEntity();
         String entityName = plugin.getEntityManager().getEntityName(livingEntity);
         Location location = LocationUtil.roundLocation(livingEntity.getLocation());

--- a/src/main/java/org/avarion/graves/listener/PlayerDeathListener.java
+++ b/src/main/java/org/avarion/graves/listener/PlayerDeathListener.java
@@ -1,19 +1,19 @@
 package org.avarion.graves.listener;
 
+import org.avarion.graves.Graves;
+import org.avarion.graves.manager.CacheManager;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-import org.avarion.graves.Graves;
-import org.avarion.graves.manager.CacheManager;
-import org.bukkit.event.Event;
-import org.bukkit.event.EventException;
-import org.bukkit.event.Listener;
-import org.bukkit.event.entity.PlayerDeathEvent;
-import org.bukkit.inventory.ItemStack;
-import org.bukkit.plugin.EventExecutor;
-
-public class PlayerDeathListener implements EventExecutor {
+public class PlayerDeathListener implements Listener {
 
     private final Graves plugin;
 
@@ -21,13 +21,9 @@ public class PlayerDeathListener implements EventExecutor {
         this.plugin = plugin;
     }
 
-    @Override
-    public void execute(Listener listener, Event event) throws EventException {
-        if (!(event instanceof PlayerDeathEvent deathEvent)) {
-            return;
-        }
-        
-        List<ItemStack> itemStackList = deathEvent.getDrops();
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onPlayerDeathEvent(@NotNull PlayerDeathEvent event) {
+        List<ItemStack> itemStackList = event.getDrops();
         Iterator<ItemStack> iterator = itemStackList.iterator();
 
         while (iterator.hasNext()) {
@@ -35,14 +31,14 @@ public class PlayerDeathListener implements EventExecutor {
 
             if (itemStack != null) {
                 if (plugin.getEntityManager().getGraveUUIDFromItemStack(itemStack) != null
-                    && plugin.getConfigBool("compass.destroy", deathEvent.getEntity())) {
+                    && plugin.getConfigBool("compass.destroy", event.getEntity())) {
                     iterator.remove();
                 }
             }
         }
 
         CacheManager.removedItemStackMap
-              .put(deathEvent.getEntity().getUniqueId(), new ArrayList<>(itemStackList));
+              .put(event.getEntity().getUniqueId(), new ArrayList<>(itemStackList));
     }
 
 }

--- a/src/main/resources/config/config.yml
+++ b/src/main/resources/config/config.yml
@@ -25,14 +25,14 @@ settings:
     
   #####################
   # Listener Priority #
-  #####################
+  ##################### 
   # The listener priority of the death event.
   # Options: LOWEST, LOW, NORMAL, HIGH, HIGHEST, MONITOR
   # The default option should work with most plugins. Unless you know what you are
-  # doing, you should leave this at HIGHEST.
+  # doing, you should leave these at their defaults.
   listener-priority:
-    death: HIGHEST    
-
+    death: MONITOR
+    
   #########
   # Debug #
   #########


### PR DESCRIPTION
Hello again, I realized I made a mistake while looking through the code in my previous pull request. It seems that the only functionality of the `PlayerDeathListener` class is to save a snapshot of the player drop list in order for the `EXACT` grave storage mode to function properly. The actual gravestone mechanics are handled in `EntityDeathListener` - therefore, this commit simply changes the configurable listener priority to be for `EntityDeathListener` instead of `PlayerDeathListener`, reverting the latter to what it was before the previous PR.