### PR TITLE
fix: make %teleport_cost% display correct value in GUI

### DIFF
--- a/src/main/java/org/avarion/graves/listener/InventoryClickListener.java
+++ b/src/main/java/org/avarion/graves/listener/InventoryClickListener.java
@@ -41,7 +41,7 @@ public class InventoryClickListener implements Listener {
                     if (grave != null) {
                         plugin.getEntityManager()
                               .runFunction(player, plugin.getConfigString("gui.menu.list.function", grave, "menu"), grave);
-                        plugin.getGUIManager().setGraveListItems(graveList.getInventory(), graveList.getUUID());
+                        plugin.getGUIManager().setGraveListItems(graveList.getInventory(), graveList.getUUID(), player);
                     }
 
                     event.setCancelled(true);
@@ -55,7 +55,7 @@ public class InventoryClickListener implements Listener {
                               .runFunction(player, plugin.getConfigString("gui.menu.grave.slot."
                                                                           + event.getSlot()
                                                                           + ".function", grave, "none"), grave);
-                        plugin.getGUIManager().setGraveMenuItems(graveMenu.getInventory(), grave);
+                        plugin.getGUIManager().setGraveMenuItems(graveMenu.getInventory(), grave, player);
                     }
 
                     event.setCancelled(true);

--- a/src/main/java/org/avarion/graves/manager/GUIManager.java
+++ b/src/main/java/org/avarion/graves/manager/GUIManager.java
@@ -11,6 +11,7 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
 
@@ -47,11 +48,11 @@ public final class GUIManager {
 
                     if (inventory.getHolder() instanceof GraveList) {
                         plugin.getGUIManager()
-                              .setGraveListItems(inventory, ((GraveList) inventory.getHolder()).getUUID());
+                              .setGraveListItems(inventory, ((GraveList) inventory.getHolder()).getUUID(), player);
                     }
                     else if (inventory.getHolder() instanceof GraveMenu) {
                         plugin.getGUIManager()
-                              .setGraveMenuItems(inventory, ((GraveMenu) inventory.getHolder()).getGrave());
+                              .setGraveMenuItems(inventory, ((GraveMenu) inventory.getHolder()).getGrave(), player);
                     }
                 }
             }
@@ -68,7 +69,7 @@ public final class GUIManager {
                 Inventory inventory = plugin.getServer()
                                             .createInventory(graveList, InventoryUtil.getInventorySize(playerGraveList.size()), StringUtil.parseString(plugin.getConfigString("gui.menu.list.title", player, permissionList, "Graves Main Menu"), player, plugin));
 
-                setGraveListItems(inventory, playerGraveList);
+                setGraveListItems(inventory, playerGraveList, player);
                 graveList.setInventory(inventory);
                 player.openInventory(graveList.getInventory());
 
@@ -82,17 +83,17 @@ public final class GUIManager {
         }
     }
 
-    public void setGraveListItems(Inventory inventory, UUID uuid) {
-        setGraveListItems(inventory, plugin.getGraveManager().getGraveList(uuid));
+    public void setGraveListItems(Inventory inventory, UUID uuid, @Nullable Player player) {
+        setGraveListItems(inventory, plugin.getGraveManager().getGraveList(uuid), player);
     }
 
-    public void setGraveListItems(@NotNull Inventory inventory, @NotNull List<Grave> graveList) {
+    public void setGraveListItems(@NotNull Inventory inventory, @NotNull List<Grave> graveList, @Nullable Player player) {
         inventory.clear();
 
         int count = 1;
 
         for (Grave grave : graveList) {
-            inventory.addItem(plugin.getItemStackManager().createGraveListItemStack(count, grave));
+            inventory.addItem(plugin.getItemStackManager().createGraveListItemStack(count, grave, player));
             count++;
         }
     }
@@ -108,7 +109,7 @@ public final class GUIManager {
             Inventory inventory = plugin.getServer()
                                         .createInventory(graveMenu, InventoryUtil.getInventorySize(5), title);
 
-            setGraveMenuItems(inventory, grave);
+            setGraveMenuItems(inventory, grave, player);
             graveMenu.setInventory(inventory);
             player.openInventory(graveMenu.getInventory());
 
@@ -118,7 +119,7 @@ public final class GUIManager {
         }
     }
 
-    public void setGraveMenuItems(@NotNull Inventory inventory, Grave grave) {
+    public void setGraveMenuItems(@NotNull Inventory inventory, Grave grave, @Nullable Player player) {
         inventory.clear();
 
         ConfigurationSection configurationSection = plugin.getConfigSection("gui.menu.grave.slot", grave);
@@ -131,7 +132,7 @@ public final class GUIManager {
         for (Map.Entry<Integer, Integer> entry : slotMapping.entrySet()) {
             int configKey = entry.getKey();
             int actualSlot = entry.getValue();
-            inventory.setItem(actualSlot, plugin.getItemStackManager().createGraveMenuItemStack(configKey, grave));
+            inventory.setItem(actualSlot, plugin.getItemStackManager().createGraveMenuItemStack(configKey, grave, player));
         }
     }
 

--- a/src/main/java/org/avarion/graves/manager/ItemStackManager.java
+++ b/src/main/java/org/avarion/graves/manager/ItemStackManager.java
@@ -6,6 +6,7 @@ import org.avarion.graves.util.StringUtil;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.BookMeta;
@@ -90,7 +91,7 @@ public final class ItemStackManager extends EntityDataManager {
         return itemStack;
     }
 
-    public @NotNull ItemStack createGraveListItemStack(int number, Grave grave) {
+    public @NotNull ItemStack createGraveListItemStack(int number, Grave grave, Player player) {
         Material material;
 
         if (plugin.getConfigBool("gui.menu.list.item.block", grave)) {
@@ -122,7 +123,7 @@ public final class ItemStackManager extends EntityDataManager {
             int customModelData = plugin.getConfigInt("gui.menu.list.model-data", grave, -1);
 
             for (String string : plugin.getConfigStringList("gui.menu.list.lore", grave)) {
-                loreList.add(ChatColor.GRAY + StringUtil.parseString(string, grave.getLocationDeath(), grave, plugin));
+                loreList.add(ChatColor.GRAY + StringUtil.parseString(string, player, grave.getLocationDeath(), grave, plugin));
             }
 
             if (plugin.getConfig().getBoolean("gui.menu.list.glow")) {
@@ -142,7 +143,7 @@ public final class ItemStackManager extends EntityDataManager {
         return itemStack;
     }
 
-    public @NotNull ItemStack createGraveMenuItemStack(int slot, Grave grave) {
+    public @NotNull ItemStack createGraveMenuItemStack(int slot, Grave grave, Player player) {
         String materialString = plugin.getConfigString("gui.menu.grave.slot." + slot + ".material", grave, "PAPER");
         Material material = Material.matchMaterial(materialString);
 
@@ -163,7 +164,7 @@ public final class ItemStackManager extends EntityDataManager {
             int customModelData = plugin.getConfigInt("gui.menu.grave.slot." + slot + ".model-data", grave, -1);
 
             for (String string : plugin.getConfigStringList("gui.menu.grave.slot." + slot + ".lore", grave)) {
-                loreList.add(ChatColor.GRAY + StringUtil.parseString(string, grave.getLocationDeath(), grave, plugin));
+                loreList.add(ChatColor.GRAY + StringUtil.parseString(string, player, grave.getLocationDeath(), grave, plugin));
             }
 
             if (plugin.getConfig().getBoolean("gui.menu.grave.slot." + slot + ".glow")) {

--- a/src/main/java/org/avarion/graves/util/StringUtil.java
+++ b/src/main/java/org/avarion/graves/util/StringUtil.java
@@ -65,8 +65,9 @@ public final class StringUtil {
             }
 
             if (string.contains("%teleport_cost%")) {
+                Location playerLocation = (entity != null) ? entity.getLocation() : location;
                 string = string.replace("%teleport_cost%", String.valueOf(plugin.getEntityManager()
-                                                                                .getTeleportCost(location, grave.getLocationDeath(), grave)));
+                                                                                .getTeleportCost(playerLocation, grave.getLocationDeath(), grave)));
             }
         }
 


### PR DESCRIPTION
## Summary

Closes #127

- `%teleport_cost%` always returned `0.0` in the GUI when `cost-distance-increase` was enabled because the distance calculation was given the same location for both endpoints (the grave's death location), resulting in distance = 0 and therefore cost = 0.
- The fix threads the viewing player through the GUI item-building stack so their actual current location is used as the starting point of the distance calculation — matching exactly how the cost is computed at the moment of teleport.

## Changes

- `StringUtil.parseString` — use the entity's location (player) as `location1` for the cost calculation when an entity is present, instead of the passed location.
- `ItemStackManager` — `createGraveMenuItemStack` and `createGraveListItemStack` now accept the viewing `Player` and pass it as the entity to `parseString`.
- `GUIManager` — `setGraveMenuItems`, `setGraveListItems`, `openGraveMenu`, `openGraveList`, and `refreshMenus` all thread the `Player` through to the item stack builders.
- `InventoryClickListener` — passes the clicking player to the two refresh calls.

## Test plan

- [ ] Enable `teleport.cost-distance-increase: true` in config
- [ ] Add `%teleport_cost%` to a GUI lore line (e.g. `gui.menu.grave.slot.X.lore`)
- [ ] Open the grave GUI from different distances — cost should scale with distance instead of always showing `0.0`
- [ ] Click teleport and confirm the charged amount matches what was displayed

🤖 Generated with [Claude Code](https://claude.com/claude-code)