### PR TITLE
fix: add bluecolored repo for BMUtils transitive dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -224,6 +224,10 @@
             <id>local-repo</id>
             <url>file://${project.basedir}/lib</url>
         </repository>
+        <repository>
+            <id>bluecolored-repo</id>
+            <url>https://repo.bluecolored.de/releases</url>
+        </repository>
     </repositories>
 
     <dependencies>


### PR DESCRIPTION
## Summary
- Adds  to the Maven repositories in 
-  v1.12.3.4 (Renovate upgrade) introduced a transitive dependency on , which is only hosted on the bluecolored repo
- Without this, CI fails to resolve the artifact while local builds succeed due to the Maven cache still having the old v1.12.3.2 POM

## Test plan
- [ ] CI build passes on the Renovate PR for  after merging this

🤖 Generated with [Claude Code](https://claude.com/claude-code)