### PR TITLE
ci: bump build JDK from 22 to 25

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          java-version: '22'
+          java-version: '25'
           distribution: 'adopt'
 
       - name: Cache Maven packages

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          java-version: '22'
+          java-version: '25'
           distribution: 'adopt'
 
       - name: Set outputs


### PR DESCRIPTION
WorldEdit 7.4.3 ships class files at major version 69 (Java 25), so javac running on JDK 22 fails to read them. This bumps the CI toolchain to JDK 25 so the build can read the new worldedit jars.

Plugin source/target stays at Java 17 via `--release 17`, so the produced bytecode is unchanged and runtime compatibility for server admins is identical.

Validated locally with JDK 25 + worldedit 7.4.3 — `mvn clean verify` succeeds and the output `Graves-*.jar` is still Java 17 bytecode (class file version 61, `0x3d`).

## Summary
- `.github/workflows/maven-build.yml`: `java-version: 22` → `25`
- `.github/workflows/maven-release.yml`: `java-version: 22` → `25`

## Test plan
- [ ] CI `build` job succeeds against master
- [ ] No change to produced bytecode target (still Java 17)

Refs EngineHub/WorldEdit#2964 (upstream issue on the patch-release Java floor bump)