### PR TITLE
chore(renovate): ignore major bumps for net.kyori:adventure-*

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,3 +1,11 @@
 {
-    "$schema": "https://docs.renovatebot.com/renovate-schema.json"
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "packageRules": [
+        {
+            "description": "Ignore major bumps for net.kyori:adventure-* — Adventure 5.x is compileOnly but the server's bundled Adventure (typically 4.x via Paper/Spigot) is what loads at runtime. Compiling against 5.x against a 4.x-bundled runtime risks NoSuchMethodError / ClassNotFoundException. Revisit once 5.x is the standard bundled version.",
+            "matchPackageNames": ["net.kyori:adventure-{/,}**"],
+            "matchUpdateTypes": ["major"],
+            "enabled": false
+        }
+    ]
 }


### PR DESCRIPTION
Equivalent to a Dependabot `@dependabot ignore this major version` for the `net.kyori:adventure-*` family.

## Why

`adventure-text-minimessage` (and friends) are `compileOnly` deps — at runtime the server's bundled Adventure (typically 4.x via Paper/Spigot) is what actually loads. Adventure 5.0 dropped many deprecated APIs, so compiling against 5.x against a 4.x-bundled runtime would surface as `NoSuchMethodError` / `ClassNotFoundException` for end users.

Closing #285 wasn't enough on its own — Renovate would re-propose 5.2.0 next month. This packageRule disables the proposal entirely for the major-update type.

When 5.x is the standard bundled version in the Paper/Spigot ecosystem, drop this rule.

## Test plan

- [ ] No `net.kyori:adventure-*` major PRs appear on next Renovate cycle
- [ ] Minor/patch updates within the same major still flow normally

Refs PaperMC/adventure#1420 (upstream Maven packaging issue).